### PR TITLE
Use BOLT 02 terminology

### DIFF
--- a/lightning-protocol-development/lightning-limitations.md
+++ b/lightning-protocol-development/lightning-limitations.md
@@ -28,7 +28,7 @@
 
 ### Spamming the Lightning Network
 
-1. What variables other than `htlc_min_val` and `max_num_htlcs` could be tweaked to make it harder or less attractive for an attacker to try and lock up a channel?
+1. What variables other than `htlc_minimum_msat` and `max_accepted_htlcs` could be tweaked to make it harder or less attractive for an attacker to try and lock up a channel?
 
 ### Limitations of lightweight clients
 


### PR DESCRIPTION
I think the terms `htlc_min_val` and `max_num_htlcs` refer to `htlc_minimum_msat` and `max_accepted_htlcs` respectively, as defined in [BOLT #02](https://github.com/lightning/bolts/blob/master/02-peer-protocol.md#the-accept_channel-message). I would propose to use the BOLT terminology in this question too?