### PR TITLE
remove answers from discussion questions

### DIFF
--- a/lightning-protocol-development/lightning-limitations.md
+++ b/lightning-protocol-development/lightning-limitations.md
@@ -51,7 +51,7 @@
 
 ### Lightning Attack Vectors
 
-1. What's to prevent an attacker from temporarily drying up network liquidity by sending himself payments using really long routes without completing the payments? By using X amount of funds, an adversary can potentially lock up an amount several times of X, depending on how long she wants to construct the routes. This attack would not cost the attacker any money, only time. It would not be possible to attribute fault to the attacker as LN is onion-routed, so the routing nodes would have no idea where exactly the money is held up. The routing nodes could also be doing this attack among themselves, to compete for market share.
+1. What's to prevent an attacker from temporarily drying up network liquidity by sending himself payments using really long routes without completing the payments?
 
 ### Pinning Attacks
 
@@ -62,4 +62,4 @@
 
 1. What are the effects of upfront fees for HTLC on malicious probing and "honest" probing?
 2. Is randomly denying a percentage of payment requests an effective countermeasure to the balance probing attack? Outside of the potential loss of routing fees, are there any other downsides?
-3. Another countermeasure was to remove error messages when a route fails. Besides having less clarity as to why a path failed when trying to find a route for a payment, are there any other reasons to include these error messages? When trying to find a path, if one of the links did not have enough capacity and you got a generic error message, you'd still keep trying enough paths and eventually get the payment through. If the problem was something else, like in the attack the destination node doesn't have the preimage for the HTLC, then after enough fails the sender would realize the problem is likely in the destination node. Is there a good use case for keeping the path error messages?
+3. Another countermeasure was to remove error messages when a route fails. Besides having less clarity as to why a path failed when trying to find a route for a payment, are there any other reasons to include these error messages?


### PR DESCRIPTION
It looks like the answers were unintentionally included in two of the discussion questions in the Lightning Limitations section.