### PR TITLE
fix broken link in welcome to bitcoin protocol

### DIFF
--- a/bitcoin-protocol-development/p2p.md
+++ b/bitcoin-protocol-development/p2p.md
@@ -12,9 +12,9 @@ _Note that this section depends on reviewing the network propagation resources o
 | [The Bitcoin Network in Mastering Bitcoin \(start at Network Discovery section\)](https://github.com/bitcoinbook/bitcoinbook/blob/b5a7b5df3eddb332311ed97af09b678257ce62ca/ch08.asciidoc#network-discovery) | 20 |
 | [Network partition resistance](https://gist.github.com/sdaftuar/c2a3320c751efb078a7c1fd834036cb0) | 20 |
 | [Eclipse Attacks on Bitcoin’s Peer-to-Peer Network](https://eprint.iacr.org/2015/263.pdf) | 75 |
-| [Network partitioning & network level privacy attacks](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-12-ethan-heilman-network-partitioning-attacks/) | 50 |
+| [Network partitioning & network level privacy attacks](https://btctranscripts.com/chaincode-residency/2019-06-12-ethan-heilman-network-partitioning-attacks/) | 50 |
 | \(_optional_\) [Transport Encryption & BIP 324](https://bip324.com/) | 15 |
-| \(_optional_\) [Researching P2P privacy attacks](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-10-09-giulia-fanti-p2p-privacy-attacks/) | 90 |
+| \(_optional_\) [Researching P2P privacy attacks](https://btctranscripts.com/chaincode-residency/2019-10-09-giulia-fanti-p2p-privacy-attacks/) | 90 |
 
 ## Optional Practical Exercise
 

--- a/bitcoin-protocol-development/script-wallets.md
+++ b/bitcoin-protocol-development/script-wallets.md
@@ -4,7 +4,7 @@
 
 | Content | Time \(min\) |
 | :--- | :--- |
-| [Bitcoin Script: Past and Future](https://btctranscripts.com/chaincode-labs/2020-04-08-john-newbery-contracts-in-bitcoin/) | 35 |
+| [Bitcoin Script: Past and Future](https://btctranscripts.com/misc/2020-04-08-john-newbery-contracts-in-bitcoin) | 35 |
 | [Script: A Mini Programming Language](https://learnmeabitcoin.com/technical/script) | 15 |
 | [Scripts \(general & simple\)](https://btctranscripts.com/scalingbitcoin/tokyo-2018/edgedevplusplus/scripts-general-and-simple/) | 40 |
 | [Miniscript: Streamlined Bitcoin Scripting](https://medium.com/blockstream/miniscript-bitcoin-scripting-3aeff3853620) | 15 |

--- a/bitcoin-protocol-development/welcome-to-the-bitcoin-protocol.md
+++ b/bitcoin-protocol-development/welcome-to-the-bitcoin-protocol.md
@@ -11,7 +11,7 @@
 | [If I'd Known What We Were Starting](https://www.linkedin.com/pulse/id-known-what-we-were-starting-ray-dillinger/) | 15 |
 | [Bitcoin's Security Model: A Deep Dive](https://www.coindesk.com/bitcoins-security-model-deep-dive) | 20 |
 | [The Onion Model of Blockchain Security](https://insights.deribit.com/market-research/the-onion-model-of-blockchain-security-part-1/) | 10 |
-| [Security Models with John Newbery](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-17-john-newbery-security-models/) | 60 |
+| [Security Models with John Newbery](https://btctranscripts.com/chaincode-residency/2019-06-17-john-newbery-security-models) | 60 |
 | [Scaling Bitcoin: A trip to the moon requires a rocket with multiple stages](https://www.reddit.com/r/Bitcoin/comments/438hx0/a_trip_to_the_moon_requires_a_rocket_with/) | 20 |
 
 ## Discussion Questions

--- a/lightning-protocol-development/future-of-lightning.md
+++ b/lightning-protocol-development/future-of-lightning.md
@@ -6,16 +6,16 @@
 | :--- | :--- |
 | [Breaking Down the Bitcoin Lightning Network: eltoo](https://medium.com/@brandonarvanaghi/breaking-down-the-bitcoin-lightning-network-eltoo-c48554f5ae02) | 15 |
 | [Eltoo by fiatjaf](https://fiatjaf.com/ffdfe772.html) | 15 |
-| \(_optional_\) [Eltoo and the Far Future](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-25-christian-decker-eltoo/) | 40 |
+| \(_optional_\) [Eltoo and the Far Future](https://btctranscripts.com/chaincode-residency/2019-06-25-christian-decker-eltoo/) | 40 |
 | \(_optional_\) [Eltoo whitepaper]( https://blockstream.com/eltoo.pdf) | 60 |
 | \(_optional_\) [Onion Messages](https://github.com/lightning/bolts/pull/759) | X |
 | [AMP/Offers/LNURL](https://vimeo.com/703262308) | 30 |
 | [Submarine Swaps](https://blog.muun.com/a-closer-look-at-submarine-swaps-in-the-lightning-network/) | 15 |
-| [Splicing](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-26-rene-pickhardt-splicing/) | 30 |
+| [Splicing](https://btctranscripts.com/chaincode-residency/2019-06-26-rene-pickhardt-splicing/) | 30 |
 | [Splices and Liquidity in the Lightning Network](https://blog.muun.com/splices-and-liquidity-in-the-lightning-network/) | 15 |
 | [Dual funded channels](https://btctranscripts.com/c-lightning/dual-funded-channels/) (until min 26) | 26 |
 | [Liquidity Advertisements](https://medium.com/blockstream/lightnings-missing-piece-a-decentralized-liquidity-market-a0bb47534a4f) | 15 |
-| [Multi-party channels/Channel factories](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-28-christian-decker-multiparty-channels/) | 20 |
+| [Multi-party channels/Channel factories](https://btctranscripts.com/chaincode-residency/2019-06-28-christian-decker-multiparty-channels/) | 20 |
 | [Payment Points: Replacing HTLCs](https://suredbits.com/payment-points-part-1/) | 15 |
 | [Payment Points: "Stuckless" Payments](https://suredbits.com/payment-points-part-2-stuckless-payments/) | 15 |
 | [Peer Backups](https://medium.com/@ACINQ/phoenix-wallet-part-3-backup-f63a9470d4e7) | 10 |

--- a/lightning-protocol-development/lightning-how-the-pieces-fit-together.md
+++ b/lightning-protocol-development/lightning-how-the-pieces-fit-together.md
@@ -8,10 +8,10 @@
 | [Creating a channel](https://ellemouton.com/posts/creating-a-channel/) | 20 |
 | [Updating State](https://ellemouton.com/posts/updating-state/) | 20 |
 | [Revocation in more detail](https://ellemouton.com/posts/revocation/) | 20 |
-| [The Update Layer](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-26-rene-pickhardt-update-layer/) | 70 |
-| [The Transfer Layer](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-24-fabrice-drouin-the-transfer-layer/) | 50 |
-| [The Multihop Layer](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-24-rene-pickhardt-multihop-in-lightning/) | 80 |
-| [The other layers \(base and transport\)](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-24-fabrice-drouin-base-and-transport-layers-of-lightning-network/) | 25 |
+| [The Update Layer](https://btctranscripts.com/chaincode-residency/2019-06-26-rene-pickhardt-update-layer/) | 70 |
+| [The Transfer Layer](https://btctranscripts.com/chaincode-residency/2019-06-24-fabrice-drouin-the-transfer-layer/) | 50 |
+| [The Multihop Layer](https://btctranscripts.com/chaincode-residency/2019-06-24-rene-pickhardt-multihop-in-lightning/) | 80 |
+| [The other layers \(base and transport\)](https://btctranscripts.com/chaincode-residency/2019-06-24-fabrice-drouin-base-and-transport-layers-of-lightning-network/) | 25 |
 | [Message format](https://github.com/lightning/bolts/blob/master/01-messaging.md#lightning-message-format) | 10 |
 | [Ok to be odd](https://github.com/lightning/bolts/blob/caae842bfcadd144ab3ec7ce74c317dca07ac78c/00-introduction.md#its-ok-to-be-odd) | 5 |
 | [TLV streams](https://github.com/lightning/bolts/blob/master/01-messaging.md#type-length-value-format) | 15 |

--- a/lightning-protocol-development/lightning-limitations.md
+++ b/lightning-protocol-development/lightning-limitations.md
@@ -10,12 +10,12 @@
 | [The price of anarchy](https://blog.bitmex.com/price-of-anarchy-from-selfish-routing-strategies/) | 30 |
 | [What Are Anchor Outputs?](https://fanismichalakis.fr/posts/anchor-outputs/) | 25 |
 | [Spamming the Lightning Network](https://github.com/t-bast/lightning-docs/blob/master/spam-prevention.md) | 40 |
-| [Limitations of lightweight clients](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-26-fabrice-drouin-limitations-of-lightweight-clients/) | 25 |
-| [Fee Management](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-25-fabrice-drouin-fee-management/) | 30 |
-| [Incentive problems in the network](https://btctranscripts.com/chaincode-labs/chaincode-residency/2018-09-18-alex-bosworth-incentive-problems-in-the-lightning-network/) | 45 |
-| [Routing Failures](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-25-fabrice-drouin-routing-failures/) | 30 |
+| [Limitations of lightweight clients](https://btctranscripts.com/chaincode-residency/2019-06-26-fabrice-drouin-limitations-of-lightweight-clients/) | 25 |
+| [Fee Management](https://btctranscripts.com/chaincode-residency/2019-06-25-fabrice-drouin-fee-management/) | 30 |
+| [Incentive problems in the network](https://btctranscripts.com/chaincode-residency/2018-09-18-alex-bosworth-incentive-problems-in-the-lightning-network/) | 45 |
+| [Routing Failures](https://btctranscripts.com/chaincode-residency/2019-06-25-fabrice-drouin-routing-failures/) | 30 |
 | [Griefing attacks](https://bitcoinmagazine.com/technical/good-griefing-a-lingering-vulnerability-on-lightning-network-that-still-needs-fixing) | 15 |
-| [Lightning Attack Vectors](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-25-fabrice-drouin-attack-vectors-of-lightning-network/) | 40 |
+| [Lightning Attack Vectors](https://btctranscripts.com/chaincode-residency/2019-06-25-fabrice-drouin-attack-vectors-of-lightning-network/) | 40 |
 | [Pinning Attacks](https://github.com/t-bast/lightning-docs/blob/master/pinning-attacks.md) | 50 |
 | [Solutions to inbound capacity problem in Lightning Network](https://medium.com/lightningto-me/practical-solutions-to-inbound-capacity-problem-in-lightning-network-60224aa13393) | 20 |
 | [Unjamming Lightning](https://research.chaincode.com/2022/11/15/unjamming-lightning/)  | 25 |

--- a/lightning-protocol-development/lightning-routing.md
+++ b/lightning-protocol-development/lightning-routing.md
@@ -6,16 +6,16 @@
 | :--- | :--- |
 | [Network topology creation & maintenance](https://btctranscripts.com/scalingbitcoin/tel-aviv-2019/edgedevplusplus/lightning-network-topology/) | 30 |
 | [Onion Routing \(video\)](https://youtu.be/toarjBSPFqI) | 15 |
-| [Onion Routing - deep dive](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-25-christian-decker-onion-routing-deep-dive/) | 50 |
+| [Onion Routing - deep dive](https://btctranscripts.com/chaincode-residency/2019-06-25-christian-decker-onion-routing-deep-dive/) | 50 |
 | [Payment Pathfinding for Reliability](https://www.youtube.com/watch?v=p8toOF-imk4) | 20 |
-| [Routing problems and solutions \(ignore rendezvous except for historical comparison\)](https://btctranscripts.com/scalingbitcoin/tel-aviv-2019/edgedevplusplus/2019-09-09-carla-kirk-cohen-routing-problems-and-solutions/) | 35 |
+| [Routing problems and solutions \(ignore rendezvous except for historical comparison\)](https://btctranscripts.com/edgedevplusplus/2019/2019-09-09-carla-kirk-cohen-routing-problems-and-solutions) | 35 |
 | [Trampoline Onion Routing](https://github.com/lightningnetwork/lightning-rfc/blob/trampoline-routing-no-gossip/proposals/trampoline.md) | 25 |
 | [Amount-independent payment routing in Lightning Networks](https://medium.com/coinmonks/amount-independent-payment-routing-in-lightning-networks-6409201ff5ed) | 15 |
 | [Multi-path payments: Making Channel Balances Add Up](https://lightning.engineering/posts/2020-05-07-mpp/) | 20 |
 | [Route Blinding](https://github.com/lightning/bolts/blob/master/proposals/route-blinding.md) | 40 |
 | [Improving error attribution](https://lists.linuxfoundation.org/pipermail/lightning-dev/2022-October/003723.html) | 20 |
 | [Rapid Gossip Sync](https://lightningdevkit.org/blog/announcing-rapid-gossip-sync/) | 20 |
-| [Gossip Protocol/Path Finding](https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-26-rene-pickhardt-path-finding-lightning-network/) | 80 |
+| [Gossip Protocol/Path Finding](https://btctranscripts.com/chaincode-residency/2019-06-26-rene-pickhardt-path-finding-lightning-network/) | 80 |
 | [Sphinx](https://github.com/t-bast/lightning-docs/blob/master/sphinx.md) | 30 |
 | \(optional\) [Optimally Reliable & Cheap Payment Flows on the Lightning Network](https://arxiv.org/pdf/2107.05322.pdf) | 60 |
 

--- a/lightning-protocol-development/payment-channels-htlcs.md
+++ b/lightning-protocol-development/payment-channels-htlcs.md
@@ -4,9 +4,9 @@
 
 | Content | Time \(min\) |
 | :--- | :--- |
-| [History of the Lightning Network](https://btctranscripts.com/chaincode-labs/chaincode-residency/2018-10-22-christian-decker-history-of-lightning/) | 60 |
+| [History of the Lightning Network](https://btctranscripts.com/chaincode-residency/2018-10-22-christian-decker-history-of-lightning/) | 60 |
 | [A Brief History of Payment Channels: from Satoshi to Lightning Network](https://old.reddit.com/r/Bitcoin/comments/cc9psl/technical_a_brief_history_of_payment_channels/) | 30 |
-| [Lightning ≈ Bitcoin](https://btctranscripts.com/chaincode-labs/chaincode-residency/2018-10-22-christian-decker-lightning-bitcoin/) | 45 |
+| [Lightning ≈ Bitcoin](https://btctranscripts.com/chaincode-residency/2018-10-22-christian-decker-lightning-bitcoin/) | 45 |
 | [Payment Channels video](https://www.youtube.com/watch?v=4SdBa8ZOfqg) or [Understanding Payment Channels article](https://blog.chainside.net/understanding-payment-channels-4ab018be79d4) | 10 or 20 |
 | [Revocable transactions with LN-Penalty](https://www.derpturkey.com/revocable-transactions-with-ln-penalty/) | 20 |
 | [A Lightning penalty transaction](https://fiatjaf.com/73095980.html) | 10 |


### PR DESCRIPTION
Fixing the broken link that was pointing to https://btctranscripts.com/chaincode-labs/chaincode-residency/2019-06-17-john-newbery-security-models and it looks like article was moved to https://btctranscripts.com/chaincode-residency/2019-06-17-john-newbery-security-models